### PR TITLE
suppress unecessary recompile

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -38,7 +38,11 @@ for c in cs:
         if os.path.exists(f'{fname}_civs.csv') and os.path.exists(f'{fname}_years.csv') and not args.force:
             print(f'Reusing {fname}_civs.csv and {fname}_years.csv')
         else:
-            cmd = f'g++ -std=c++17 -O3 -Wall -Werror -Wextra -Wshadow -Wno-sign-compare simulate.cc && ./a.out {D} {code_n} {N} {s} {c} {L} {fname} {seed} {empty_samples} {m} {volume_points} {volume_radii} 2>{fname}.out'
+            if not os.path.exists(f'./a.out'):
+                cmd = 'g++ -std=c++17 -O3 -Wall -Werror -Wextra -Wshadow -Wno-sign-compare simulate.cc'
+                print(cmd)
+                subprocess.run(cmd, shell=True)
+            cmd = f'./a.out {D} {code_n} {N} {s} {c} {L} {fname} {seed} {empty_samples} {m} {volume_points} {volume_radii} 2>{fname}.out'
             print(cmd)
             subprocess.check_output(cmd, shell=True)
             print(f'Generated {fname}_civs.csv and {fname}_years.csv')


### PR DESCRIPTION
As written, the python script recompiles the C++ code on every iteration. With this change the python script builds a.out only if it does not already exist - which allows the script to run much faster. The user can force a rebuild by deleting a.out. A cleaner solution would be to implement a Makefile that rebuilds a.out any time the source code changes.