### PR TITLE
suppress matplotlib warning

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -139,7 +139,7 @@ if args.table_1:
 
 def plot(ax, label, target_c, log):
     ax.minorticks_on()
-    ax.grid(b=True, which='major', axis='both')
+    ax.grid(visible=True, which='major', axis='both')
     ax.tick_params(axis='both', which='both', bottom=True, left=True)
     ax.set_xlabel('Percentile')
     for (c,n),(CIVS,YEARS) in DATA.items():


### PR DESCRIPTION
suppress Matplotlib warning:

analyze.py:143: MatplotlibDeprecationWarning: The 'b' parameter of grid() has been renamed 'visible' since Matplotlib 3.5; support for the old name will be dropped two minor releases later.